### PR TITLE
the final keyword is redundant on private methods.

### DIFF
--- a/src/main/java/com/conversantmedia/util/concurrent/ConcurrentStack.java
+++ b/src/main/java/com/conversantmedia/util/concurrent/ConcurrentStack.java
@@ -299,7 +299,7 @@ public final class ConcurrentStack<N> implements BlockingStack<N> {
         }
     }
 
-    private final boolean isFull() {
+    private boolean isFull() {
         return size == stackTop.get();
     }
 

--- a/src/main/java/com/conversantmedia/util/concurrent/DisruptorBlockingQueue.java
+++ b/src/main/java/com/conversantmedia/util/concurrent/DisruptorBlockingQueue.java
@@ -443,7 +443,7 @@ public final class DisruptorBlockingQueue<E> extends MultithreadConcurrentQueue<
         return new RingIter();
     }
 
-    private final boolean isFull() {
+    private boolean isFull() {
         final long queueStart = tail.get() - size;
         return head.get() == queueStart;
     }

--- a/src/main/java/com/conversantmedia/util/concurrent/PushPullBlockingQueue.java
+++ b/src/main/java/com/conversantmedia/util/concurrent/PushPullBlockingQueue.java
@@ -331,7 +331,7 @@ public final class PushPullBlockingQueue<E> extends PushPullConcurrentQueue<E> i
         return new RingIter();
     }
 
-    private final boolean isFull() {
+    private boolean isFull() {
         final long queueStart = tail.get() - size;
         return head.get() == queueStart;
     }

--- a/src/main/java/com/conversantmedia/util/estimation/Percentile.java
+++ b/src/main/java/com/conversantmedia/util/estimation/Percentile.java
@@ -173,7 +173,7 @@ public class Percentile {
         return q[2*m+3];
     }
 
-    private final void addMeasurement(final float x) {
+    private void addMeasurement(final float x) {
         int k=1;
 
         if(x < q[1]) {

--- a/src/main/java/com/conversantmedia/util/estimation/PercentileFile.java
+++ b/src/main/java/com/conversantmedia/util/estimation/PercentileFile.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  */
 public final class PercentileFile {
 
-    public static final void main(final String[] arg) throws IOException {
+    public static void main(final String[] arg) throws IOException {
 
 
         for(int i=0; i<arg.length; i++) {


### PR DESCRIPTION
So far, this change does not seem to impact performance:

1.  the conversant disruptor benchmark test results are the same, with and without the final keyword
2.  the generated byte code for one class, PushPullBlockingQueue, is nearly the same, with and without the final keyword

That's not proof and I have not yet dipped below the surface of the more critical parts of the project.

