### PR TITLE
PushPullBlockingQueue removeAll(Collection) and retainAll(Collection)

### DIFF
--- a/src/main/java/com/conversantmedia/util/concurrent/PushPullBlockingQueue.java
+++ b/src/main/java/com/conversantmedia/util/concurrent/PushPullBlockingQueue.java
@@ -299,31 +299,19 @@ public final class PushPullBlockingQueue<E> extends PushPullConcurrentQueue<E> i
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        int numFalses = 0;
-        for (final Object o : c) {
-            if (!remove(o)) numFalses++;
-        }
-        return numFalses > 0;
+        if (c.isEmpty()) return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        int numFalses = 0;
-
         for (int i = 0; i < size(); i++) {
             final int headSlot = (int) ((head.get() + i) & mask);
             if (!c.contains(buffer[headSlot])) {
-                if (!remove(buffer[headSlot])) {
-                    numFalses++;
-                } else {
-                    // backtrack one step, we just backed values up at this point
-                    i--;
-                }
-
+                throw new UnsupportedOperationException();
             }
         }
-
-        return numFalses > 0;
+        return false;
     }
 
     @Override

--- a/src/test/java/com/conversantmedia/util/concurrent/PushPullBlockingQueueTest.java
+++ b/src/test/java/com/conversantmedia/util/concurrent/PushPullBlockingQueueTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -620,6 +621,24 @@ public class PushPullBlockingQueueTest {
         Assert.assertFalse(dbq.containsAll(si));
     }
 
+    @Test
+    public void testRemoveAll_with_empty_Collection_returns_false_with_no_exception() {
+
+        final int cap = 8;
+        final BlockingQueue<Integer> dbq = new PushPullBlockingQueue<>(cap);
+
+        final Set<Integer> set = new HashSet();
+
+        for(int i=0; i<cap; i++) {
+            set.add(i);
+        }
+
+        dbq.addAll(set);
+
+        Assert.assertFalse(dbq.removeAll(Collections.emptySet()));
+        Assert.assertEquals(cap, dbq.size());
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testRetainAll() {
 
@@ -640,6 +659,21 @@ public class PushPullBlockingQueueTest {
         Assert.assertEquals(cap/10, dbq.size());
 
         dbq.containsAll(si);
+    }
+
+    @Test
+    public void testRetainAll_with_equal_Collection_returns_false_with_no_exception() {
+        final int cap = 100;
+        final BlockingQueue<Integer> dbq = new PushPullBlockingQueue<Integer>(cap);
+        Set<Integer> si = new HashSet(cap);
+
+        for(int i=0; i<cap; i++) {
+            si.add(Integer.valueOf(i));
+            dbq.offer(Integer.valueOf(i));
+        }
+
+        Assert.assertFalse(dbq.retainAll(si));
+        Assert.assertEquals(cap, dbq.size());
     }
 
     @Test(timeout=30000)


### PR DESCRIPTION
removeAll(Collection) _never returns true_ because remove(Collection) throws an Exception; 
removeAll(Collection) returns false on _only one_ condition: the collection is empty.
Otherwise, removeAll(Collection) always throws an Exception.

Similarly, retainAll(Collection) _never returns true_.
retainAll(Collection) returns false on _only one_ condition: the queue's elements are a subset of the collection. 
Otherwise, retainAll(Collection) always throws an Exception.

See unit tests added.

