### PR TITLE
enable Dependabot v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

Dependabot v2 can detect:
- outdated Maven plugins
- outdated Java libraries
